### PR TITLE
Community backport - adds keepalive connection checks

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,5 +41,6 @@ Creating a new release of network proxy involves releasing a new version of the 
 
     ```
     ./hack/pin-dependency.sh sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+    make clean generated_files
     ./hack/update-vendor.sh
     ```

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -40,9 +40,19 @@ type GrpcProxyAgentOptions struct {
 	SyncInterval     time.Duration
 	ProbeInterval    time.Duration
 	SyncIntervalCap  time.Duration
+	// After a duration of this time if the agent doesn't see any activity it
+	// pings the server to see if the transport is still alive.
+	KeepaliveTime time.Duration
 
 	// file contains service account authorization token for enabling proxy-server token based authorization
 	ServiceAccountTokenPath string
+
+	// This warns if we attempt to push onto a "full" transfer channel.
+	// However checking that the transfer channel is full is not safe.
+	// It violates our race condition checking. Adding locks around a potentially
+	// blocking call has its own problems, so it cannot easily be made race condition safe.
+	// The check is an "unlocked" read but is still use at your own peril.
+	WarnOnChannelLimit bool
 }
 
 func (o *GrpcProxyAgentOptions) ClientSetConfig(dialOptions ...grpc.DialOption) *agent.ClientSetConfig {
@@ -55,6 +65,7 @@ func (o *GrpcProxyAgentOptions) ClientSetConfig(dialOptions ...grpc.DialOption) 
 		SyncIntervalCap:         o.SyncIntervalCap,
 		DialOptions:             dialOptions,
 		ServiceAccountTokenPath: o.ServiceAccountTokenPath,
+		WarnOnChannelLimit:      o.WarnOnChannelLimit,
 	}
 }
 
@@ -74,8 +85,10 @@ func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 	flags.DurationVar(&o.SyncInterval, "sync-interval", o.SyncInterval, "The initial interval by which the agent periodically checks if it has connections to all instances of the proxy server.")
 	flags.DurationVar(&o.ProbeInterval, "probe-interval", o.ProbeInterval, "The interval by which the agent periodically checks if its connections to the proxy server are ready.")
 	flags.DurationVar(&o.SyncIntervalCap, "sync-interval-cap", o.SyncIntervalCap, "The maximum interval for the SyncInterval to back off to when unable to connect to the proxy server")
+	flags.DurationVar(&o.KeepaliveTime, "keepalive-time", o.KeepaliveTime, "Time for gRPC agent server keepalive.")
 	flags.StringVar(&o.ServiceAccountTokenPath, "service-account-token-path", o.ServiceAccountTokenPath, "If non-empty proxy agent uses this token to prove its identity to the proxy server.")
 	flags.StringVar(&o.AgentIdentifiers, "agent-identifiers", o.AgentIdentifiers, "Identifiers of the agent that will be used by the server when choosing agent. N.B. the list of identifiers must be in URL encoded format. e.g.,host=localhost&host=node1.mydomain.com&cidr=127.0.0.1/16&ipv4=1.2.3.4&ipv4=5.6.7.8&ipv6=:::::&default-route=true")
+	flags.BoolVar(&o.WarnOnChannelLimit, "warn-on-channel-limit", o.WarnOnChannelLimit, "Turns on a warning if the system is going to push to a full channel. The check involves an unsafe read.")
 	return flags
 }
 
@@ -94,8 +107,10 @@ func (o *GrpcProxyAgentOptions) Print() {
 	klog.V(1).Infof("SyncInterval set to %v.\n", o.SyncInterval)
 	klog.V(1).Infof("ProbeInterval set to %v.\n", o.ProbeInterval)
 	klog.V(1).Infof("SyncIntervalCap set to %v.\n", o.SyncIntervalCap)
+	klog.V(1).Infof("Keepalive time set to %v.\n", o.KeepaliveTime)
 	klog.V(1).Infof("ServiceAccountTokenPath set to %q.\n", o.ServiceAccountTokenPath)
 	klog.V(1).Infof("AgentIdentifiers set to %s.\n", util.PrettyPrintURL(o.AgentIdentifiers))
+	klog.V(1).Infof("WarnOnChannelLimit set to %t.\n", o.WarnOnChannelLimit)
 }
 
 func (o *GrpcProxyAgentOptions) Validate() error {
@@ -181,7 +196,9 @@ func NewGrpcProxyAgentOptions() *GrpcProxyAgentOptions {
 		SyncInterval:              1 * time.Second,
 		ProbeInterval:             1 * time.Second,
 		SyncIntervalCap:           10 * time.Second,
+		KeepaliveTime:             1 * time.Hour,
 		ServiceAccountTokenPath:   "",
+		WarnOnChannelLimit:        false,
 	}
 	return &o
 }

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -44,6 +45,20 @@ func NewProxyCommand(p *Proxy, o *options.ProxyRunOptions) *cobra.Command {
 	}
 
 	return cmd
+}
+
+func tlsCipherSuites(cipherNames []string) []uint16 {
+	// return nil, so use default cipher list
+	if len(cipherNames) == 0 {
+		return nil
+	}
+
+	acceptedCiphers := util.GetAcceptedCiphers()
+	ciphersIntSlice := make([]uint16, 0)
+	for _, cipher := range cipherNames {
+		ciphersIntSlice = append(ciphersIntSlice, acceptedCiphers[cipher])
+	}
+	return ciphersIntSlice
 }
 
 type Proxy struct {
@@ -170,7 +185,10 @@ func (p *Proxy) runUDSFrontendServer(ctx context.Context, o *options.ProxyRunOpt
 	}
 	var stop StopFunc
 	if o.Mode == "grpc" {
-		grpcServer := grpc.NewServer()
+		frontendServerOptions := []grpc.ServerOption{
+			grpc.KeepaliveParams(keepalive.ServerParameters{Time: o.FrontendKeepaliveTime}),
+		}
+		grpcServer := grpc.NewServer(frontendServerOptions...)
 		client.RegisterProxyServiceServer(grpcServer, s)
 		lis, err := getUDSListener(ctx, o.UdsName)
 		if err != nil {
@@ -208,14 +226,16 @@ func (p *Proxy) runUDSFrontendServer(ctx context.Context, o *options.ProxyRunOpt
 	return stop, nil
 }
 
-func (p *Proxy) getTLSConfig(caFile, certFile, keyFile string) (*tls.Config, error) {
+func (p *Proxy) getTLSConfig(caFile, certFile, keyFile, cipherSuites string) (*tls.Config, error) {
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load X509 key pair %s and %s: %v", certFile, keyFile, err)
 	}
 
+	cipherSuiteIDs := tlsCipherSuites(strings.Split(cipherSuites, ","))
+
 	if caFile == "" {
-		return &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}, nil
+		return &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12, CipherSuites: cipherSuiteIDs}, nil
 	}
 
 	certPool := x509.NewCertPool()
@@ -227,11 +247,13 @@ func (p *Proxy) getTLSConfig(caFile, certFile, keyFile string) (*tls.Config, err
 	if !ok {
 		return nil, fmt.Errorf("failed to append cluster CA cert to the cert pool")
 	}
+
 	tlsConfig := &tls.Config{
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{cert},
 		ClientCAs:    certPool,
 		MinVersion:   tls.VersionTLS12,
+		CipherSuites: cipherSuiteIDs,
 	}
 
 	return tlsConfig, nil
@@ -242,7 +264,7 @@ func (p *Proxy) runMTLSFrontendServer(ctx context.Context, o *options.ProxyRunOp
 
 	var tlsConfig *tls.Config
 	var err error
-	if tlsConfig, err = p.getTLSConfig(o.ServerCaCert, o.ServerCert, o.ServerKey); err != nil {
+	if tlsConfig, err = p.getTLSConfig(o.ServerCaCert, o.ServerCert, o.ServerKey, o.CipherSuites); err != nil {
 		return nil, err
 	}
 
@@ -291,7 +313,7 @@ func (p *Proxy) runMTLSFrontendServer(ctx context.Context, o *options.ProxyRunOp
 func (p *Proxy) runAgentServer(o *options.ProxyRunOptions, server *server.ProxyServer) error {
 	var tlsConfig *tls.Config
 	var err error
-	if tlsConfig, err = p.getTLSConfig(o.ClusterCaCert, o.ClusterCert, o.ClusterKey); err != nil {
+	if tlsConfig, err = p.getTLSConfig(o.ClusterCaCert, o.ClusterCert, o.ClusterKey, o.CipherSuites); err != nil {
 		return err
 	}
 

--- a/examples/kubernetes/konnectivity-agent.yaml
+++ b/examples/kubernetes/konnectivity-agent.yaml
@@ -19,7 +19,9 @@ spec:
     image: ${AGENT_IMAGE}:${TAG}
     resources:
       requests:
-        cpu: 40m
+        cpu: 50m
+      limits:
+        memory: 30Mi
     command: [ "/proxy-agent"]
     args: [
       "--logtostderr=true",
@@ -35,10 +37,6 @@ spec:
         path: /healthz
       initialDelaySeconds: 15
       timeoutSeconds: 15
-    resources:
-      limits:
-        cpu: 50m
-        memory: 30Mi
     volumeMounts:
       - mountPath: /var/run/secrets/tokens
         name: konnectivity-agent-token

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.1.2
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.5
@@ -30,6 +29,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.4.1 // indirect
 	github.com/imdario/mergo v0.3.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,7 +99,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -246,7 +245,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -463,7 +461,6 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.27.1 h1:zvIju4sqAGvwKspUQOhwnpcqSbzi7/H6QomNNjTL4sk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -55,6 +55,8 @@ type ClientSet struct {
 
 	agentIdentifiers string // The identifiers of the agent, which will be used
 	// by the server when choosing agent
+
+	warnOnChannelLimit bool
 }
 
 func (cs *ClientSet) ClientsCount() int {
@@ -121,6 +123,7 @@ type ClientSetConfig struct {
 	SyncIntervalCap         time.Duration
 	DialOptions             []grpc.DialOption
 	ServiceAccountTokenPath string
+	WarnOnChannelLimit      bool
 }
 
 func (cc *ClientSetConfig) NewAgentClientSet(stopCh <-chan struct{}) *ClientSet {
@@ -134,6 +137,7 @@ func (cc *ClientSetConfig) NewAgentClientSet(stopCh <-chan struct{}) *ClientSet 
 		syncIntervalCap:         cc.SyncIntervalCap,
 		dialOptions:             cc.DialOptions,
 		serviceAccountTokenPath: cc.ServiceAccountTokenPath,
+		warnOnChannelLimit:      cc.WarnOnChannelLimit,
 		stopCh:                  stopCh,
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -388,6 +388,7 @@ func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
 			}
 			if err != nil {
 				klog.ErrorS(err, "Stream read from frontend failure")
+				stopCh <- err
 				close(stopCh)
 				return
 			}
@@ -666,6 +667,7 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 			}
 			if err != nil {
 				klog.ErrorS(err, "stream read failure")
+				stopCh <- err
 				close(stopCh)
 				return
 			}

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"crypto/tls"
 	"strings"
 )
 
@@ -47,4 +48,13 @@ func RemovePortFromHost(host string) string {
 		host = host[:strings.LastIndexByte(host, ':')]
 	}
 	return strings.Trim(host, "[]")
+}
+
+// GetAcceptedCiphers returns all the ciphers supported by the crypto/tls package
+func GetAcceptedCiphers() map[string]uint16 {
+	acceptedCiphers := make(map[string]uint16, len(tls.CipherSuites()))
+	for _, v := range tls.CipherSuites() {
+		acceptedCiphers[v.Name] = v.ID
+	}
+	return acceptedCiphers
 }


### PR DESCRIPTION
Key changes pulled in:

Keepalive and connection healthchecking parameters exposed for konnectivity agents and server.

Adjusted some channel sizes to have it not block on connections that download larger payloads

Additional logging of errors on grpc channel errors.