### PR TITLE
CNTRLPLANE-3380: Update OWNERS with HyperShift core team

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,23 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sjenning
-  - enxebre
+  - bryan-cox
+  - clebs
   - csrwng
+  - devguyio
+  - enxebre
+  - jparrill
+  - muraee
+  - Nirshal
   - relyt0925
-approvers:
+  - sdminonne
   - sjenning
-  - enxebre
+approvers:
+  - bryan-cox
   - csrwng
+  - devguyio
+  - enxebre
+  - jparrill
+  - muraee
+  - sjenning
 component: hypershift


### PR DESCRIPTION
## Summary
- Adds HyperShift core reviewers and approvers to align with the main hypershift repo
- New reviewers: `bryan-cox`, `clebs`, `devguyio`, `jparrill`, `muraee`, `Nirshal`, `sdminonne`
- New approvers: `bryan-cox`, `devguyio`, `jparrill`, `muraee`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This update contains **no user-facing changes**. Internal administrative updates have been made to governance and review processes for the hypershift component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->