### PR TITLE
NO-JIRA: Update OpenShift carry patches for Go 1.26 / OpenShift 5.0

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.23
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.23 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy
 
@@ -7,7 +7,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -v -a -ldflags '-extldflags "-static"' -o proxy-server sigs.k8s.io/apiserver-network-proxy/cmd/server
 RUN CGO_ENABLED=0 go build -v -a -ldflags '-extldflags "-static"' -o proxy-agent sigs.k8s.io/apiserver-network-proxy/cmd/agent
 
-FROM registry.ci.openshift.org/ocp/4.23:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 
 COPY --from=builder /go/src/sigs.k8s.io/apiserver-network-proxy/proxy-server /usr/bin/proxy-server
 COPY --from=builder /go/src/sigs.k8s.io/apiserver-network-proxy/proxy-agent /usr/bin/proxy-agent

--- a/pkg/server/desthost_backend_manager.go
+++ b/pkg/server/desthost_backend_manager.go
@@ -79,10 +79,25 @@ func (dibm *DestHostBackendManager) Backend(ctx context.Context) (*Backend, erro
 	if destHost != "" {
 		bes, exist := dibm.backends[destHost]
 		if exist && len(bes) > 0 {
-			klog.V(5).InfoS("Get the backend through the DestHostBackendManager", "destHost", destHost)
-			//TODO: change dibm.random.Intn(len(bes)) to be in sync with community when they fix
-			// https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/261
-			return dibm.backends[destHost][dibm.random.Intn(len(bes))], nil
+			var firstDrainingBackend *Backend
+
+			// Find a non-draining backend for this destination host
+			for _, backend := range bes {
+				if !backend.IsDraining() {
+					klog.V(5).InfoS("Get the backend through the DestHostBackendManager", "destHost", destHost)
+					return backend, nil
+				}
+				// Keep track of first draining backend as fallback
+				if firstDrainingBackend == nil {
+					firstDrainingBackend = backend
+				}
+			}
+
+			// All backends for this destination are draining, use one as fallback
+			if firstDrainingBackend != nil {
+				klog.V(3).InfoS("All backends for destination host are draining, using one as fallback", "destHost", destHost)
+				return firstDrainingBackend, nil
+			}
 		}
 	}
 	return nil, &ErrNotFound{}

--- a/pkg/server/desthost_backend_manager.go
+++ b/pkg/server/desthost_backend_manager.go
@@ -79,25 +79,19 @@ func (dibm *DestHostBackendManager) Backend(ctx context.Context) (*Backend, erro
 	if destHost != "" {
 		bes, exist := dibm.backends[destHost]
 		if exist && len(bes) > 0 {
-			var firstDrainingBackend *Backend
+			klog.V(5).InfoS("Get the backend through the DestHostBackendManager", "destHost", destHost)
 
-			// Find a non-draining backend for this destination host
-			for _, backend := range bes {
-				if !backend.IsDraining() {
-					klog.V(5).InfoS("Get the backend through the DestHostBackendManager", "destHost", destHost)
-					return backend, nil
-				}
-				// Keep track of first draining backend as fallback
-				if firstDrainingBackend == nil {
-					firstDrainingBackend = backend
+			var nonDraining []*Backend
+			for _, be := range bes {
+				if !be.IsDraining() {
+					nonDraining = append(nonDraining, be)
 				}
 			}
-
-			// All backends for this destination are draining, use one as fallback
-			if firstDrainingBackend != nil {
-				klog.V(3).InfoS("All backends for destination host are draining, using one as fallback", "destHost", destHost)
-				return firstDrainingBackend, nil
+			if len(nonDraining) > 0 {
+				return nonDraining[dibm.random.Intn(len(nonDraining))], nil
 			}
+			klog.V(3).InfoS("All backends for destination host are draining, using one as fallback", "destHost", destHost)
+			return bes[dibm.random.Intn(len(bes))], nil
 		}
 	}
 	return nil, &ErrNotFound{}


### PR DESCRIPTION
## Summary
- Update `.ci-operator.yaml` builder image from `golang-1.25-openshift-4.23` to `golang-1.26-openshift-5.0`
- Update `Dockerfile.openshift` builder and base images to match (`golang-1.26-openshift-5.0` and `ocp/5.0:base-rhel9`)
- Drop the "load balance traffic across redundant backends" carry for `DestHostBackendManager` — upstream issue #261 is closed and upstream now has draining-aware backend selection that the carry was removing

## Test plan
- [ ] CI jobs on this PR pass (verify, verify-deps, unit, images)
- [ ] After merge, re-trigger the rebase bot periodic to regenerate PR #111 with the updated carry commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend selection to preferentially route traffic to non-draining backends for a destination host, with an automatic fallback to ensure traffic continues even when all candidates are draining.

* **Chores**
  * Updated CI release image tag and refreshed OpenShift builder and runtime base images to newer OpenShift/RHEL and Go versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->